### PR TITLE
Make sure output ``logs`` directory exists

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 
 import click
@@ -173,6 +174,7 @@ def main(
     storage.commit(f"Processed {len(jobs)} chunks")
 
     # save logs
+    os.makedirs("logs", exist_ok=True)
     log_fname = f"logs/{int(datetime.now().timestamp())}-{serverless_backend}.csv"
     save_output_log(results, log_fname)
 


### PR DESCRIPTION
I was playing playing around with this today and got this error

```
Traceback (most recent call last):
  File "/Users/james/projects/earth-mover/serverless-datacube-demo/src/main.py", line 181, in <module>
    main()
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/projects/earth-mover/serverless-datacube-demo/src/main.py", line 177, in main
    save_output_log(results, log_fname)
  File "/Users/james/projects/earth-mover/serverless-datacube-demo/src/lib.py", line 322, in save_output_log
    df.to_csv(fname, index=False)
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/pandas/util/_decorators.py", line 333, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/pandas/core/generic.py", line 3967, in to_csv
    return DataFrameRenderer(formatter).to_csv(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/pandas/io/formats/format.py", line 1014, in to_csv
    csv_formatter.save()
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/pandas/io/formats/csvs.py", line 251, in save
    with get_handle(
         ^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/pandas/io/common.py", line 749, in get_handle
    check_parent_directory(str(handle))
  File "/Users/james/mambaforge/envs/datacube-env5/lib/python3.11/site-packages/pandas/io/common.py", line 616, in check_parent_directory
    raise OSError(rf"Cannot save file into a non-existent directory: '{parent}'")
OSError: Cannot save file into a non-existent directory: 'logs'
```

because it's assumed the output `logs` directory already exists. This PR just adds a line of code to make sure the `logs` directory is around. 